### PR TITLE
[OD-303] Configure ckanext-twitter

### DIFF
--- a/ckanext/twitter/controllers/tweet.py
+++ b/ckanext/twitter/controllers/tweet.py
@@ -1,7 +1,7 @@
 import json
 
 import ckan.lib.base as base
-from ckan.common import c
+from ckan.common import c, session
 from ckanext.twitter.lib import twitter_api
 
 
@@ -29,4 +29,11 @@ class TweetController(base.BaseController):
             'success': posted,
             'reason': reason,
             'tweet': text if text else 'tweet not defined'
+            })
+
+    def no_tweet(self, pkg_id):
+        session.pop('twitter_is_suitable', '')
+        session.save()
+        return json.dumps({
+            'success': True
             })

--- a/ckanext/twitter/controllers/tweet.py
+++ b/ckanext/twitter/controllers/tweet.py
@@ -31,7 +31,7 @@ class TweetController(base.BaseController):
             'tweet': text if text else 'tweet not defined'
             })
 
-    def no_tweet(self, pkg_id):
+    def disable_tweet_popup(self):
         session.pop('twitter_is_suitable', '')
         session.save()
         return json.dumps({

--- a/ckanext/twitter/lib/config_helpers.py
+++ b/ckanext/twitter/lib/config_helpers.py
@@ -35,6 +35,13 @@ def twitter_hours_between_tweets():
     '''
     return pylons.config.get('ckanext.twitter.hours_between_tweets', 24)
 
+def tweet_trigger():
+    '''
+    For trigger the tweet whether at Dataset or Resource
+    :return: int
+    '''
+    return pylons.config.get('ckanext.twitter.tweet_trigger')
+
 
 def twitter_new_format():
     '''

--- a/ckanext/twitter/lib/parsers.py
+++ b/ckanext/twitter/lib/parsers.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from pylons import config
 
-tweet_limit = 140
+tweet_limit = 280
 
 
 def extract_info(context, pkg_dict, template_length, tokens):
@@ -148,7 +148,7 @@ def generate_tweet(context, pkg_id, is_new, force_truncate = True):
     template = Environment().from_string(format_string)
     simplified_dict = extract_info(context, pkg,
                                    len(unicode(template.module)), tokens)
-    simplified_dict['dataset_url'] = str(config.get('ckan.site_url'))+'/dataset/activity/'+pkg['name']
+    simplified_dict['dataset_url'] = str(config.get('ckan.site_url'))+'/dataset/activity/'+pkg['id']
     rendered = template.render(simplified_dict)
     # extra check to make sure the tweet isn't too long
     if len(rendered) > tweet_limit and force_truncate:

--- a/ckanext/twitter/lib/parsers.py
+++ b/ckanext/twitter/lib/parsers.py
@@ -6,6 +6,11 @@ from ckan.logic import get_action
 from ckanext.twitter.lib import config_helpers
 from jinja2 import Environment
 
+try:
+    from ckan.common import config
+except ImportError:
+    from pylons import config
+
 tweet_limit = 140
 
 
@@ -143,6 +148,7 @@ def generate_tweet(context, pkg_id, is_new, force_truncate = True):
     template = Environment().from_string(format_string)
     simplified_dict = extract_info(context, pkg,
                                    len(unicode(template.module)), tokens)
+    simplified_dict['dataset_url'] = str(config.get('ckan.site_url'))+'/dataset/activity/'+pkg['name']
     rendered = template.render(simplified_dict)
     # extra check to make sure the tweet isn't too long
     if len(rendered) > tweet_limit and force_truncate:

--- a/ckanext/twitter/plugin.py
+++ b/ckanext/twitter/plugin.py
@@ -40,7 +40,6 @@ class TwitterPlugin(p.SingletonPlugin):
 
     # IResourceController
     def after_update(self, context, res_pkg_dict):
-        print ckanext.twitter.lib.config_helpers.tweet_trigger()
         if ckanext.twitter.lib.config_helpers.tweet_trigger() == 'dataset':
             pkg_dict = res_pkg_dict
         else:

--- a/ckanext/twitter/plugin.py
+++ b/ckanext/twitter/plugin.py
@@ -39,7 +39,7 @@ class TwitterPlugin(p.SingletonPlugin):
     def after_update(self, context, pkg_dict):
         is_suitable = twitter_helpers.twitter_pkg_suitable(context,
                                                            pkg_dict['id'])
-        if is_suitable:
+        if is_suitable and 'Twitter_Popup' in pkg_dict.get('twitter_popup', []):
             session.pop('twitter_is_suitable', '')
             session.setdefault('twitter_is_suitable', pkg_dict['id'])
             session.save()

--- a/ckanext/twitter/plugin.py
+++ b/ckanext/twitter/plugin.py
@@ -35,7 +35,6 @@ class TwitterPlugin(p.SingletonPlugin):
         # Add resources
         p.toolkit.add_resource('theme/fanstatic', 'ckanext-twitter')
 
-
     # IPackageController
     def after_update(self, context, pkg_dict):
         is_suitable = twitter_helpers.twitter_pkg_suitable(context,

--- a/ckanext/twitter/plugin.py
+++ b/ckanext/twitter/plugin.py
@@ -35,11 +35,13 @@ class TwitterPlugin(p.SingletonPlugin):
         # Add resources
         p.toolkit.add_resource('theme/fanstatic', 'ckanext-twitter')
 
+
     # IPackageController
     def after_update(self, context, pkg_dict):
         is_suitable = twitter_helpers.twitter_pkg_suitable(context,
                                                            pkg_dict['id'])
         if is_suitable:
+            session.pop('twitter_is_suitable', '')
             session.setdefault('twitter_is_suitable', pkg_dict['id'])
             session.save()
 
@@ -57,6 +59,11 @@ class TwitterPlugin(p.SingletonPlugin):
         controller = 'ckanext.twitter.controllers.tweet:TweetController'
         _map.connect('post_tweet', '/dataset/{pkg_id}/tweet',
                      controller = controller, action = 'send',
+                     conditions = {
+                         'method': ['POST']
+                         })
+        _map.connect('no_tweet', '/dataset/{pkg_id}/no-tweet',
+                     controller = controller, action = 'no_tweet',
                      conditions = {
                          'method': ['POST']
                          })

--- a/ckanext/twitter/plugin.py
+++ b/ckanext/twitter/plugin.py
@@ -62,8 +62,8 @@ class TwitterPlugin(p.SingletonPlugin):
                      conditions = {
                          'method': ['POST']
                          })
-        _map.connect('no_tweet', '/dataset/{pkg_id}/no-tweet',
-                     controller = controller, action = 'no_tweet',
+        _map.connect('no_tweet', '/dataset/disable-tweet-popup',
+                     controller = controller, action = 'disable_tweet_popup',
                      conditions = {
                          'method': ['POST']
                          })

--- a/ckanext/twitter/theme/fanstatic/scripts/modules/confirm-tweet.js
+++ b/ckanext/twitter/theme/fanstatic/scripts/modules/confirm-tweet.js
@@ -11,7 +11,7 @@ ckan.module('confirm-tweet', function ($, _) {
                     _onReceiveSnippet: function (html) {
                         var url    = '/dataset/' + self.options.pkgid + '/tweet';
                         self.modal = $(html);
-                        var form   = self.modal.find('#edit-tweet-form');                        
+                        var form   = self.modal.find('#edit-tweet-form');             
                         form.submit(function (e) {
                             e.preventDefault();
                             $.post(url,
@@ -39,7 +39,7 @@ ckan.module('confirm-tweet', function ($, _) {
                                     self.modal.modal('hide');
                                 },
                                 'json'
-                         )
+                            )
                         })
                         self.modal.modal().appendTo(self.sandbox.body);
                     },

--- a/ckanext/twitter/theme/fanstatic/scripts/modules/confirm-tweet.js
+++ b/ckanext/twitter/theme/fanstatic/scripts/modules/confirm-tweet.js
@@ -11,7 +11,7 @@ ckan.module('confirm-tweet', function ($, _) {
                     _onReceiveSnippet: function (html) {
                         var url    = '/dataset/' + self.options.pkgid + '/tweet';
                         self.modal = $(html);
-                        var form   = self.modal.find('#edit-tweet-form');
+                        var form   = self.modal.find('#edit-tweet-form');                        
                         form.submit(function (e) {
                             e.preventDefault();
                             $.post(url,
@@ -31,7 +31,16 @@ ckan.module('confirm-tweet', function ($, _) {
                                    'json'
                             )
                         });
-
+                        self.modal.find('.no-tweet').click(function(e){
+                            var url_tweet    = '/dataset/' + self.options.pkgid + '/no-tweet';
+                            $.post(url_tweet,
+                                form.serialize(),
+                                function (results) {
+                                    self.modal.modal('hide');
+                                },
+                                'json'
+                         )
+                        })
                         self.modal.modal().appendTo(self.sandbox.body);
                     },
 

--- a/ckanext/twitter/theme/fanstatic/scripts/modules/confirm-tweet.js
+++ b/ckanext/twitter/theme/fanstatic/scripts/modules/confirm-tweet.js
@@ -11,7 +11,7 @@ ckan.module('confirm-tweet', function ($, _) {
                     _onReceiveSnippet: function (html) {
                         var url    = '/dataset/' + self.options.pkgid + '/tweet';
                         self.modal = $(html);
-                        var form   = self.modal.find('#edit-tweet-form');             
+                        var form   = self.modal.find('#edit-tweet-form');   
                         form.submit(function (e) {
                             e.preventDefault();
                             $.post(url,

--- a/ckanext/twitter/theme/fanstatic/scripts/modules/confirm-tweet.js
+++ b/ckanext/twitter/theme/fanstatic/scripts/modules/confirm-tweet.js
@@ -32,9 +32,9 @@ ckan.module('confirm-tweet', function ($, _) {
                             )
                         });
                         self.modal.find('.no-tweet').click(function(e){
-                            var url_tweet    = '/dataset/' + self.options.pkgid + '/no-tweet';
+                            var url_tweet    = '/dataset/disable-tweet-popup';
                             $.post(url_tweet,
-                                form.serialize(),
+                                {},
                                 function (results) {
                                     self.modal.modal('hide');
                                 },

--- a/ckanext/twitter/theme/templates/ajax_snippets/edit_tweet.html
+++ b/ckanext/twitter/theme/templates/ajax_snippets/edit_tweet.html
@@ -26,7 +26,7 @@
                 <button class="btn btn-danger cancel no-tweet" type="button" name="cancel">{{ _('No') }}
                 </button>
             </div>
-        </form>    
+        </form>
         {% endblock %}
     </div>
 </div>

--- a/ckanext/twitter/theme/templates/ajax_snippets/edit_tweet.html
+++ b/ckanext/twitter/theme/templates/ajax_snippets/edit_tweet.html
@@ -23,10 +23,10 @@
             <div class="form-actions">
                 {{ form.required_message() }}
                 <button class="btn btn-primary save" type="submit" name="save">{{ _('Yes') }}</button>
-                <button class="btn btn-danger cancel" type="button" data-dismiss="modal" name="cancel">{{ _('No') }}
+                <button class="btn btn-danger cancel no-tweet" type="button" name="cancel">{{ _('No') }}
                 </button>
             </div>
-        </form>
+        </form>    
         {% endblock %}
     </div>
 </div>

--- a/ckanext/twitter/theme/templates/package/base.html
+++ b/ckanext/twitter/theme/templates/package/base.html
@@ -3,7 +3,6 @@
 {% block flash %}
 {{ super() }}
 {% resource 'ckanext-twitter/confirm-tweet' %}
-
 {% if h.tweet_ready(pkg.id) %}
 <input type="hidden" data-module="confirm-tweet" data-module-tweet="{{ h.get_tweet(pkg.id) }}"
        data-module-pkgid="{{ pkg.id }}" data-module-disable_edit="{{ h.disable_edit() }}">

--- a/ckanext/twitter/theme/templates/package/base.html
+++ b/ckanext/twitter/theme/templates/package/base.html
@@ -3,6 +3,7 @@
 {% block flash %}
 {{ super() }}
 {% resource 'ckanext-twitter/confirm-tweet' %}
+
 {% if h.tweet_ready(pkg.id) %}
 <input type="hidden" data-module="confirm-tweet" data-module-tweet="{{ h.get_tweet(pkg.id) }}"
        data-module-pkgid="{{ pkg.id }}" data-module-disable_edit="{{ h.disable_edit() }}">


### PR DESCRIPTION
[OD-303](https://opengovinc.atlassian.net/browse/OD-303) Configure ckanext-twitter

Need to update the extension so that the twitter box does not popup again if the user clicks No to tweet. Currently the popup occurs every single time the user visits the dataset even if they click No.
Test Procedures

-- Install the PR
-- Open the CKAN site and log in as a sysadmin
-- Navigate to the /dataset page and select any dataset
-- Click on Manage
-- Update anything from the selected dataset
-- Once update you will get the twiiter pop-up
-- If user click on No then pop up won't appear until next update